### PR TITLE
Enhancements to FtpSourceTask: batch processing, improved resilience, and scalability for large files

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each file is read line by line, and each line is sent as an independent Kafka re
   - A structured `JSON` (`Schema + Struct`)
 - Optional field mapping via `ftp.file.headers`
 - Optional Kafka key based on one or more fields (`ftp.kafka.key.field`)
+- Limit records returned per poll (`ftp.max.records.per.poll`)
 - Moves files to:
   - A staging folder before processing
   - An archive folder after processing
@@ -48,6 +49,7 @@ Each file is read line by line, and each line is sent as an independent Kafka re
     "ftp.file.headers": "type,date,time,code,value",
     "ftp.kafka.key.field": "type+code",
     "ftp.poll.interval.ms": "10000",
+    "ftp.max.records.per.poll": "1000",
     "topic": "ftp-data-topic",
     "tasks.max": "1"
   }

--- a/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceConnector.java
+++ b/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceConnector.java
@@ -29,6 +29,8 @@ public class FtpSourceConnector extends SourceConnector {
         public static final String FTP_FILE_HEADERS = "ftp.file.headers";
         public static final String FTP_KAFKA_KEY_FIELD = "ftp.kafka.key.field";
 
+        public static final String FTP_MAX_RECORDS_PER_POLL = "ftp.max.records.per.poll";
+
         public static final String FTP_POLL_INTERVAL = "ftp.poll.interval.ms";
 
         public static final String TOPIC = "topic";
@@ -95,6 +97,8 @@ public class FtpSourceConnector extends SourceConnector {
                                                 "Field name from headers to be used as Kafka message key")
                                 .define(FTP_POLL_INTERVAL, ConfigDef.Type.INT, 10000, ConfigDef.Importance.LOW,
                                                 "Polling interval in milliseconds")
+                                .define(FTP_MAX_RECORDS_PER_POLL, ConfigDef.Type.INT, 1000, ConfigDef.Importance.LOW,
+                                                "Maximum number of records returned per poll")
                                 .define(TOPIC, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
                                                 "Kafka topic to publish the file data");
         }

--- a/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceTask.java
+++ b/src/main/java/br/com/datastreambrasil/kafka/connector/ftp/FtpSourceTask.java
@@ -109,7 +109,7 @@ public class FtpSourceTask extends SourceTask {
             }
 
             boolean eof = false;
-            String line;
+            String line = null;
             while (records.size() < maxRecordsPerPoll && (line = currentReader.readLine()) != null) {
                 Map<String, String> sourcePartition = Collections.singletonMap("file", currentFilename);
                 Map<String, Long> sourceOffset = Collections.singletonMap("position", System.currentTimeMillis());


### PR DESCRIPTION
This PR introduces significant improvements to the FtpSourceTask component of the FTP Source Kafka Connector.

**Key changes:**
- Implements batch/incremental file processing with stateful tracking (current file, offset, lines processed).
- Adds a configurable `maxRecordsPerPoll` parameter to avoid overloading the worker and improve scalability.
- Keeps file streams/readers open and resumes reading from the last processed line, making it more efficient for large files.
- Adds progress logs every 10,000 lines to facilitate monitoring and troubleshooting.
- Safely archives files only after full processing, preventing potential data loss in case of interruptions.

**Benefits:**
- Much higher resilience and scalability for environments with large or numerous files.
- Lower risk of worker failures or Out Of Memory errors.
- Improved observability for production usage.

A full report with details is available [here](LINK_TO_YOUR_MARKDOWN).

Let me know if you have any questions or need further changes.

Cheers,  
Douglas Dalo
